### PR TITLE
Fix: Prevent console window minimization when launching Agent.exe

### DIFF
--- a/internal/process/launcher.go
+++ b/internal/process/launcher.go
@@ -4,6 +4,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
+)
+
+const (
+	// CreateNoWindow prevents the creation of a console window for the process
+	CreateNoWindow = 0x08000000
+	// CreateNewProcessGroup creates a new process group, detaching from parent's console
+	CreateNewProcessGroup = 0x00000200
 )
 
 // LaunchProcess starts a new process from the given executable path
@@ -15,6 +23,12 @@ func LaunchProcess(executablePath string) error {
 
 	// Create command to launch the process
 	cmd := exec.Command(executablePath)
+
+	// Set Windows-specific process attributes to prevent window minimization
+	// and hide the child process window completely
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: CreateNoWindow | CreateNewProcessGroup,
+	}
 
 	// Start the process in detached mode (don't wait for it to finish)
 	err := cmd.Start()


### PR DESCRIPTION
## Summary

This PR fixes the issue where the multiablo.exe console window automatically minimizes when `LaunchProcess()` is called to relaunch Agent.exe.

## Changes

Modified `internal/process/launcher.go`:
- Added `syscall` import for Windows API access
- Defined Windows process creation flag constants:
  - `CREATE_NO_WINDOW (0x08000000)` - Prevents console window creation
  - `CREATE_NEW_PROCESS_GROUP (0x00000200)` - Creates new process group
- Updated `LaunchProcess()` to set `SysProcAttr.CreationFlags` with the above flags

## Technical Details

The root cause was that without explicit `SysProcAttr` configuration, the child process (Agent.exe) inherited the parent process's window attributes, causing the parent console window to minimize.

By setting the Windows creation flags:
1. **CREATE_NO_WINDOW**: Agent.exe runs completely hidden in the background with no visible window
2. **CREATE_NEW_PROCESS_GROUP**: Agent.exe is placed in a new process group, preventing it from inheriting or affecting the parent's console state

## Testing

### Build
```bash
go build -o multiablo.exe ./cmd/multiablo
```

### Manual Testing Steps
1. Double-click `multiablo.exe` from Windows Explorer (not from cmd)
2. Start D2R from Battle.net launcher
3. Wait for Agent.exe to be terminated and relaunched by multiablo.exe
4. Verify:
   - ✅ multiablo.exe console window remains visible (does not minimize)
   - ✅ Agent.exe process is running but has no visible window
   - ✅ Can confirm with `tasklist /v` or Process Explorer

## Impact

- **Files modified**: 1 file (`internal/process/launcher.go`)
- **Functions affected**: 1 function (`LaunchProcess()`)
- **Dependencies**: None added (syscall is standard library)
- **Breaking changes**: None (function signature unchanged)
- **Backward compatibility**: Fully maintained

## References

- Fixes #8
- [Windows CreateProcess dwCreationFlags documentation](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)