### PR TITLE
ci: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -35,7 +35,7 @@ jobs:
           go build -ldflags="-s -w -H windowsgui" -o multiablo.exe ./cmd/multiablo
 
       - name: Upload Binary Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: multiablo-binary
           path: multiablo.exe

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Binary Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: multiablo-binary
           

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -18,7 +18,7 @@ jobs:
   translate-and-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Translate to Traditional Chinese
         uses: FidelusAleksander/ai-translate-action@v1
@@ -66,7 +66,7 @@ jobs:
           JA: ${{ steps.translate-ja.outputs.translated-text }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "docs: update README translations"
           title: "docs: update README translations"


### PR DESCRIPTION
Bumps GitHub Actions to their latest major versions.

### build.yml
- actions/checkout v4 -> v7
- actions/setup-go v5 -> v6
- actions/upload-artifact v4 -> v7

### translate.yml
- actions/checkout v4 -> v7
- peter-evans/create-pull-request v6 -> v8
- (FidelusAleksander/ai-translate-action@v1 left as-is — already latest moving major)

### release-please.yml
- googleapis/release-please-action v4 -> v5

ci.yml uses a local reusable workflow and was left unchanged.